### PR TITLE
Add missing font-weight to guides

### DIFF
--- a/guides/_layouts/default.html
+++ b/guides/_layouts/default.html
@@ -8,7 +8,7 @@
     {% else %}
       <title>GraphQL - {{ page.title }}</title>
     {% endif %}
-    <link href="https://fonts.googleapis.com/css?family=Rubik:300,400" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css?family=Rubik:300,400,700" rel="stylesheet" />
     <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
     <link rel="icon" href="{{ site.baseurl }}/graphql-ruby-icon.png">
   </head>


### PR DESCRIPTION
This is how the guide looks in Chrome:

![image](https://user-images.githubusercontent.com/1242960/135302513-eb6fcdcd-ab07-442f-92ee-96c08c02428c.png)

Bold text is blurry and not really bold, because the right font is missing:

![image](https://user-images.githubusercontent.com/1242960/135302584-2b3f1263-b0ca-4ce1-85c4-ee43e6cdc70a.png)

And this is how it looks when all font weights are loaded:

![image](https://user-images.githubusercontent.com/1242960/135302732-fc424a83-682e-4646-8614-e8b488a0e28c.png)
